### PR TITLE
fixing IPE restart issue.

### DIFF
--- a/src/IPE_Wrapper.F90
+++ b/src/IPE_Wrapper.F90
@@ -61,9 +61,6 @@ CONTAINS
       RETURN
     ENDIF
 
-    ! Set IPE run mode to coupled
-    ipe % forcing % coupled = .true.
-
     ! Set IPE internal clock
     CALL ESMF_ClockGet(clock, startTime=startTime, currTime=currTime, rc=localrc)
     IF( ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -76,6 +73,12 @@ CONTAINS
       line=__LINE__, &
       FILE=__FILE__, &
       rcToReturn=rc) ) RETURN  ! bail out
+
+    ! Set IPE run mode to coupled
+    ipe % forcing % coupled = .true.
+
+    ! Set IPE start time
+    ipe % forcing % start_time = ipe % time_tracker % elapsed_sec
 
     init_file = "IPE_State.apex."//ipe % time_tracker % DateStamp( )//".h5"
     INQUIRE( FILE = TRIM(init_file), EXIST = file_exists, IOSTAT = localrc )
@@ -106,6 +109,7 @@ CONTAINS
         rcToReturn=rc)
       RETURN
     ENDIF
+
 
   END SUBROUTINE Initialize_IPE
 

--- a/src/ipelib/IPE_Forcing_Class.F90
+++ b/src/ipelib/IPE_Forcing_Class.F90
@@ -260,7 +260,7 @@ CONTAINS
         line=__LINE__, file=__FILE__, rc=rc ) ) RETURN
     end if
 
-    forcing % current_index = INT( (deltime - forcing % start_time / real(forcing % ifp_interval) ) &
+    forcing % current_index = INT( (deltime - forcing % start_time) / real(forcing % ifp_interval) ) &
                                   + forcing % ifp_skip + 1
 
   END SUBROUTINE Update_Current_Index

--- a/src/ipelib/IPE_Forcing_Class.F90
+++ b/src/ipelib/IPE_Forcing_Class.F90
@@ -260,7 +260,8 @@ CONTAINS
         line=__LINE__, file=__FILE__, rc=rc ) ) RETURN
     end if
 
-    forcing % current_index = INT( deltime / real(forcing % ifp_interval) ) + forcing % ifp_skip + 1
+    forcing % current_index = INT( (deltime - forcing % start_time / real(forcing % ifp_interval) ) &
+                                  + forcing % ifp_skip + 1
 
   END SUBROUTINE Update_Current_Index
 

--- a/src/ipelib/IPE_Forcing_Class.F90
+++ b/src/ipelib/IPE_Forcing_Class.F90
@@ -16,6 +16,7 @@ IMPLICIT NONE
 
     REAL(prec)              :: dt
     REAL(prec)              :: current_time
+    REAL(prec)              :: start_time
     INTEGER                 :: current_index
     INTEGER                 :: max_read_index
     INTEGER                 :: ifp_interval
@@ -88,6 +89,7 @@ CONTAINS
     dt            = parameters % solar_forcing_time_step
 
     forcing % dt            = parameters % solar_forcing_time_step
+    forcing % start_time    = 0.0_prec
     forcing % current_time  = 0.0_prec
     forcing % current_index = 1
 

--- a/src/ipelib/IPE_Model_Class.F90
+++ b/src/ipelib/IPE_Model_Class.F90
@@ -213,7 +213,7 @@ CONTAINS
       call ipe % forcing % Update_Current_Index( ipe % parameters, &
                                                  ipe % mpi_layer, &
                                                  ipe % forcing_io, &
-                                                 ipe % time_tracker % elapsed_sec - ipe % forcing % start_time, &
+                                                 ipe % time_tracker % elapsed_sec, &
                                                  rc = localrc )
       IF ( ipe_error_check( localrc, msg="Failed to update neutrals", &
         line=__LINE__, file=__FILE__, rc=rc ) ) RETURN

--- a/src/ipelib/IPE_Model_Class.F90
+++ b/src/ipelib/IPE_Model_Class.F90
@@ -213,7 +213,7 @@ CONTAINS
       call ipe % forcing % Update_Current_Index( ipe % parameters, &
                                                  ipe % mpi_layer, &
                                                  ipe % forcing_io, &
-                                                 ipe % time_tracker % elapsed_sec, &
+                                                 ipe % time_tracker % elapsed_sec - ipe % forcing % start_time, &
                                                  rc = localrc )
       IF ( ipe_error_check( localrc, msg="Failed to update neutrals", &
         line=__LINE__, file=__FILE__, rc=rc ) ) RETURN


### PR DESCRIPTION
When coupled, IPE's clock is synced to ESMF's clock; as a result, the elapsed_sec at initialization (non-zero during restarts, or during IAU) in the time_tracker always needs to be subtracted from the current elapsed_sec for the purposes of indexing the space weather driver arrays.