### PR TITLE
rc default value unset bugfix

### DIFF
--- a/src/ipelib/IPE_Forcing_Class.F90
+++ b/src/ipelib/IPE_Forcing_Class.F90
@@ -261,6 +261,8 @@ CONTAINS
     ! Local
     INTEGER :: localrc
 
+    rc = IPE_SUCCESS
+
     forcing % current_index = INT( deltime / real(params % f107_kp_interval) ) + &
                                       1 + params % f107_kp_skip_size
 

--- a/src/ipelib/IPE_Model_Class.F90
+++ b/src/ipelib/IPE_Model_Class.F90
@@ -200,7 +200,7 @@ CONTAINS
       call ipe % forcing % Update_Current_Index( ipe % parameters, &
                                                  ipe % time_tracker % elapsed_sec, &
                                                  rc = localrc )
-      IF ( ipe_error_check( localrc, msg="Failed to update neutrals", &
+      IF ( ipe_error_check( localrc, msg="Failed to update driver index", &
         line=__LINE__, file=__FILE__, rc=rc ) ) RETURN
 
       CALL ipe % neutrals % Update( ipe % parameters, &


### PR DESCRIPTION
Some newer compilers require this; it's a fundamental bug.