### PR TITLE
NRLMSISE00 Storm Mode & Weimer Fix

### DIFF
--- a/src/ipelib/IPE_Neutrals_Class.F90
+++ b/src/ipelib/IPE_Neutrals_Class.F90
@@ -8,7 +8,7 @@ MODULE IPE_Neutrals_Class
   USE ipe_error_module
 
   ! MSIS
-  USE physics_msis ! gtd7
+  USE physics_msis ! gtd7, tselec
   USE utils_constants, ONLY : msis_dp => dp
 
   IMPLICIT NONE
@@ -77,7 +77,13 @@ CONTAINS
 
     INTEGER :: stat
 
+    REAL(msis_dp), DIMENSION(25):: switch
+
     IF ( PRESENT( rc ) ) rc = IPE_SUCCESS
+
+    switch(:) =  1.0_msis_dp
+    switch(9) = -1.0_msis_dp
+    CALL tselec( switch )
 
     neutrals % nFluxTube = nFluxTube
     neutrals % NLP       = NLP
@@ -392,6 +398,7 @@ CONTAINS
           msis_stl     = REAL(time % utime / 3600.0_prec + geo_lon / 15.0_prec, KIND=msis_dp)
           densities    = 0.0_msis_dp
           temperatures = 0.0_msis_dp
+
 
           call gtd7( iyd,         &    ! Input, year and day as yyddd
                      msis_sec,    &    ! Input, universal time ( sec )

--- a/src/ipelib/dynamo/module_weimer2005Ipe.f
+++ b/src/ipelib/dynamo/module_weimer2005Ipe.f
@@ -1,3 +1,4 @@
+
 !-----------------------------------------------------------------------
       module module_weimer2005Ipe
 !module w05sc
@@ -30,7 +31,7 @@
       real*8 :: bndyfitr        ! calculated by setboundary
       real*8 :: esphc(csize),bsphc(csize) ! calculated by setmodel
       real*8 :: tmat(3,3),ttmat(3,3) ! from setboundary
-      integer,parameter :: mxtablesize=200
+      integer,parameter :: mxtablesize=225
       real*8 :: plmtable(mxtablesize,csize)
       real*8 :: colattable(mxtablesize)
       real*8 :: nlms(csize)
@@ -338,11 +339,9 @@
       th0 = bndyfitr
       if (prevth0 /= th0) then
          tablesize = 3*nint(th0)
-         if (tablesize > mxtablesize) then 
-           write(errmsg,"('>>> tablesize > mxtablesize: tablesize=',i5,
-     &' mxtablesize=',i5,' tn0=',e12.4)") tablesize,mxtablesize,th0
-           call ipe_error_set(msg=errmsg, rc=rc)
-           return
+         if (tablesize > mxtablesize) then ! clamp to existing limit
+           th0 = real(mxtablesize, 8) / 3 - 0.5
+           tablesize = 3 * nint(th0) ! always <= mxtablesize
          endif
 !     write(6,"('scplm: indx=',i3,' colat=',f8.3,' th0=',e12.4,&
 !       &' tablesize=',i3)") indx,colat,th0,tablesize


### PR DESCRIPTION
**Weimer fix**

High lat potential fix: raise cap for equatorward convection in Weimer and set return to that cap (or close to the cap) rather than to 0 in the event it exceeds the empirical table size.

**NRLMSISE00 Storm Mode**

Polar regions, <120km have bad values in some neutrals under high geomagnetic conditions, which is partially addressed with "storm mode" enabled. TBD: Update MSIS.